### PR TITLE
update readme to include R env

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ conda env create -f environment.yml
 conda activate simulate_expression_compendia
 ```
 
+Additional statistical packages from R bioconductor are required:
+
+Using R 3.6.3 install the following packages:
+```
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+
+BiocManager::install("limma")
+BiocManager::install("sva")
+``` 
+
 ## How to run this simulation using your own data
 
 In order to run this simulation on your own gene expression data the following steps should be performed:

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
 name: simulate_expression_compendia
 channels:
-- anaconda
 - conda-forge
-- defaults
 dependencies:
 - conda-forge::python=3.5.5
 - conda-forge::keras=2.1.6
@@ -28,6 +26,7 @@ dependencies:
 - conda-forge::rpy2=2.8
 - conda-forge::libiconv=1.15
 - conda-forge::joblib=0.13.2
+- pip=9.0
 - pip:
   - torch>=0.4.0
   - matplotlib==3.0.0


### PR DESCRIPTION
This PR adds information to the Readme to specify the R environment that is required to run this repo.

I initially tried to install this R environment using conda but I ran into conflicts with the version of python I'm using and after digging around the internet I couldn't find a work around that allowed me to keep the existing packages the same version. Since this repo is near completion, I have added instructions to the readme to document instead.