### PR TITLE
Update nb to use transposed matrix

### DIFF
--- a/Human/Human_experiment_lvl_sim.ipynb
+++ b/Human/Human_experiment_lvl_sim.ipynb
@@ -171,7 +171,8 @@
     "if os.path.exists(normalized_data_file) == False:\n",
     "    pipeline.normalize_expression_data(base_dir,\n",
     "                                       config_file,\n",
-    "                                       rpkm_data_file)"
+    "                                       rpkm_data_file,\n",
+    "                                       normalized_data_file)"
    ]
   },
   {
@@ -242,11 +243,11 @@
    "outputs": [],
    "source": [
     "# Run simulation without correction \n",
-    "#corrected=False\n",
-    "#pipeline.run_simulation(config_file,\n",
-    "#                         normalized_data_file,\n",
-    "#                        corrected,\n",
-    "#                        experiment_id_file)"
+    "corrected=False\n",
+    "pipeline.run_simulation(config_file,\n",
+    "                        normalized_data_file,\n",
+    "                        corrected,\n",
+    "                        experiment_id_file)"
    ]
   },
   {

--- a/Human/Human_sample_lvl_sim.ipynb
+++ b/Human/Human_sample_lvl_sim.ipynb
@@ -162,7 +162,8 @@
     "if os.path.exists(normalized_data_file) == False:\n",
     "    pipeline.normalize_expression_data(base_dir,\n",
     "                                       config_file,\n",
-    "                                       rpkm_data_file)"
+    "                                       rpkm_data_file,\n",
+    "                                       normalized_data_file)"
    ]
   },
   {
@@ -295,9 +296,9 @@
    "source": [
     "# Train VAE\n",
     "# Check if VAE training completed first\n",
-    "#if len(os.listdir(vae_log_dir)) == 0:\n",
-    "pipeline.train_vae(config_file,\n",
-    "                   normalized_data_file)"
+    "if len(os.listdir(vae_log_dir)) == 0:\n",
+    "    pipeline.train_vae(config_file,\n",
+    "                       normalized_data_file)"
    ]
   },
   {
@@ -1248,7 +1249,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1262,7 +1263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/Human/nbconverted/Human_experiment_lvl_sim.py
+++ b/Human/nbconverted/Human_experiment_lvl_sim.py
@@ -128,7 +128,8 @@ normalized_data_file = os.path.join(
 if os.path.exists(normalized_data_file) == False:
     pipeline.normalize_expression_data(base_dir,
                                        config_file,
-                                       rpkm_data_file)
+                                       rpkm_data_file,
+                                       normalized_data_file)
 
 
 # In[8]:
@@ -171,11 +172,11 @@ if len(os.listdir(vae_log_dir)) == 0:
 
 
 # Run simulation without correction 
-#corrected=False
-#pipeline.run_simulation(config_file,
-#                         normalized_data_file,
-#                        corrected,
-#                        experiment_id_file)
+corrected=False
+pipeline.run_simulation(config_file,
+                        normalized_data_file,
+                        corrected,
+                        experiment_id_file)
 
 
 # ## Run simulation with correction applied

--- a/Human/nbconverted/Human_sample_lvl_sim.py
+++ b/Human/nbconverted/Human_sample_lvl_sim.py
@@ -119,7 +119,8 @@ normalized_data_file = os.path.join(
 if os.path.exists(normalized_data_file) == False:
     pipeline.normalize_expression_data(base_dir,
                                        config_file,
-                                       rpkm_data_file)
+                                       rpkm_data_file,
+                                       normalized_data_file)
 
 
 # ## Train VAE
@@ -140,9 +141,9 @@ vae_log_dir = os.path.join(
 
 # Train VAE
 # Check if VAE training completed first
-#if len(os.listdir(vae_log_dir)) == 0:
-pipeline.train_vae(config_file,
-                   normalized_data_file)
+if len(os.listdir(vae_log_dir)) == 0:
+    pipeline.train_vae(config_file,
+                       normalized_data_file)
 
 
 # ## Run simulation experiment without noise correction

--- a/Pseudomonas/Pseudomonas_experiment_lvl_sim.ipynb
+++ b/Pseudomonas/Pseudomonas_experiment_lvl_sim.ipynb
@@ -115,6 +115,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output files\n",
+    "normalized_processed_data_file = os.path.join(\n",
+    "    base_dir,\n",
+    "    dataset_name,\n",
+    "    \"data\",\n",
+    "    \"input\",\n",
+    "    \"train_set_normalized_processed.txt.xz\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -128,6 +143,24 @@
    "outputs": [],
    "source": [
     "pipeline.setup_dir(config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process data\n",
+    "This pipeline is expecting data to be of the form sample x gene. The downloaded data is gene x sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.transpose_data(normalized_data_file,\n",
+    "                        normalized_processed_data_file)"
    ]
   },
   {
@@ -161,9 +194,9 @@
     "# Only run pre-processind step if experiment id file is NOT created\n",
     "if os.path.exists(experiment_id_file) == False:\n",
     "    pipeline.create_experiment_id_file(metadata_file,\n",
-    "                                      normalized_data_file,\n",
-    "                                      experiment_id_file,\n",
-    "                                      config_file)"
+    "                                       normalized_processed_data_file,\n",
+    "                                       experiment_id_file,\n",
+    "                                       config_file)"
    ]
   },
   {
@@ -199,7 +232,7 @@
     "# Check if VAE training completed first\n",
     "if len(os.listdir(vae_log_dir)) == 0:\n",
     "    pipeline.train_vae(config_file,\n",
-    "                       normalized_data_file)"
+    "                       normalized_processed_data_file)"
    ]
   },
   {
@@ -284,7 +317,7 @@
     "# Run simulation without correction \n",
     "corrected=False\n",
     "pipeline.run_simulation(config_file,\n",
-    "                        normalized_data_file,\n",
+    "                        normalized_processed_data_file,\n",
     "                        corrected,\n",
     "                        experiment_id_file)"
    ]
@@ -371,7 +404,7 @@
     "# Run simulation without correction\n",
     "corrected=True\n",
     "pipeline.run_simulation(config_file,\n",
-    "                        normalized_data_file,\n",
+    "                        normalized_processed_data_file,\n",
     "                        corrected,\n",
     "                        experiment_id_file)"
    ]

--- a/Pseudomonas/Pseudomonas_sample_lvl_sim.ipynb
+++ b/Pseudomonas/Pseudomonas_sample_lvl_sim.ipynb
@@ -108,6 +108,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output files\n",
+    "normalized_processed_data_file = os.path.join(\n",
+    "    base_dir,\n",
+    "    dataset_name,\n",
+    "    \"data\",\n",
+    "    \"input\",\n",
+    "    \"train_set_normalized_processed.txt.xz\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -121,6 +136,24 @@
    "outputs": [],
    "source": [
     "pipeline.setup_dir(config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Process data\n",
+    "This pipeline is expecting data to be of the form sample x gene. The downloaded data is gene x sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.transpose_data(normalized_data_file,\n",
+    "                        normalized_processed_data_file)"
    ]
   },
   {
@@ -381,7 +414,7 @@
     "# Check if VAE training completed first\n",
     "if len(os.listdir(vae_log_dir)) == 0:\n",
     "    pipeline.train_vae(config_file,\n",
-    "                       normalized_data_file)"
+    "                       normalized_processed_data_file)"
    ]
   },
   {
@@ -456,7 +489,7 @@
    "source": [
     "# Run simulation without correction \n",
     "pipeline.run_simulation(config_file,\n",
-    "                        normalized_data_file,\n",
+    "                        normalized_processed_data_file,\n",
     "                        corrected=False)"
    ]
   },
@@ -532,7 +565,7 @@
    "source": [
     "# Run simulation without correction \n",
     "pipeline.run_simulation(config_file,\n",
-    "                        normalized_data_file,\n",
+    "                        normalized_processed_data_file,\n",
     "                        corrected=True)"
    ]
   },

--- a/Pseudomonas/data/input/train_set_normalized_processed.txt.xz
+++ b/Pseudomonas/data/input/train_set_normalized_processed.txt.xz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbf750db179495aa47be3d654879a878e6d092fdb772ee035e3a3b0f5070254d
+size 32133528

--- a/Pseudomonas/nbconverted/Pseudomonas_experiment_lvl_sim.py
+++ b/Pseudomonas/nbconverted/Pseudomonas_experiment_lvl_sim.py
@@ -90,12 +90,34 @@ metadata_file = os.path.join(
     "sample_annotations.tsv")
 
 
+# In[ ]:
+
+
+# Output files
+normalized_processed_data_file = os.path.join(
+    base_dir,
+    dataset_name,
+    "data",
+    "input",
+    "train_set_normalized_processed.txt.xz")
+
+
 # ## Setup directories
 
 # In[5]:
 
 
 pipeline.setup_dir(config_file)
+
+
+# ## Process data
+# This pipeline is expecting data to be of the form sample x gene. The downloaded data is gene x sample.
+
+# In[ ]:
+
+
+pipeline.transpose_data(normalized_data_file,
+                        normalized_processed_data_file)
 
 
 # ## Pre-process data
@@ -118,9 +140,9 @@ experiment_id_file = os.path.join(
 # Only run pre-processind step if experiment id file is NOT created
 if os.path.exists(experiment_id_file) == False:
     pipeline.create_experiment_id_file(metadata_file,
-                                      normalized_data_file,
-                                      experiment_id_file,
-                                      config_file)
+                                       normalized_processed_data_file,
+                                       experiment_id_file,
+                                       config_file)
 
 
 # ## Train VAE
@@ -143,7 +165,7 @@ vae_log_dir = os.path.join(
 # Check if VAE training completed first
 if len(os.listdir(vae_log_dir)) == 0:
     pipeline.train_vae(config_file,
-                       normalized_data_file)
+                       normalized_processed_data_file)
 
 
 # ## Run simulation experiment without noise correction
@@ -154,7 +176,7 @@ if len(os.listdir(vae_log_dir)) == 0:
 # Run simulation without correction 
 corrected=False
 pipeline.run_simulation(config_file,
-                        normalized_data_file,
+                        normalized_processed_data_file,
                         corrected,
                         experiment_id_file)
 
@@ -167,7 +189,7 @@ pipeline.run_simulation(config_file,
 # Run simulation without correction
 corrected=True
 pipeline.run_simulation(config_file,
-                        normalized_data_file,
+                        normalized_processed_data_file,
                         corrected,
                         experiment_id_file)
 

--- a/Pseudomonas/nbconverted/Pseudomonas_sample_lvl_sim.py
+++ b/Pseudomonas/nbconverted/Pseudomonas_sample_lvl_sim.py
@@ -83,12 +83,34 @@ normalized_data_file = os.path.join(
     "train_set_normalized.pcl")
 
 
+# In[ ]:
+
+
+# Output files
+normalized_processed_data_file = os.path.join(
+    base_dir,
+    dataset_name,
+    "data",
+    "input",
+    "train_set_normalized_processed.txt.xz")
+
+
 # ## Setup directories
 
 # In[10]:
 
 
 pipeline.setup_dir(config_file)
+
+
+# ## Process data
+# This pipeline is expecting data to be of the form sample x gene. The downloaded data is gene x sample.
+
+# In[ ]:
+
+
+pipeline.transpose_data(normalized_data_file,
+                        normalized_processed_data_file)
 
 
 # ## Train VAE
@@ -111,7 +133,7 @@ vae_log_dir = os.path.join(
 # Check if VAE training completed first
 if len(os.listdir(vae_log_dir)) == 0:
     pipeline.train_vae(config_file,
-                       normalized_data_file)
+                       normalized_processed_data_file)
 
 
 # ## Run simulation experiment without noise correction
@@ -121,7 +143,7 @@ if len(os.listdir(vae_log_dir)) == 0:
 
 # Run simulation without correction 
 pipeline.run_simulation(config_file,
-                        normalized_data_file,
+                        normalized_processed_data_file,
                         corrected=False)
 
 
@@ -132,7 +154,7 @@ pipeline.run_simulation(config_file,
 
 # Run simulation without correction 
 pipeline.run_simulation(config_file,
-                        normalized_data_file,
+                        normalized_processed_data_file,
                         corrected=True)
 
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Further customization can be accomplished by doing the following:
 | kappa | float: How fast to linearly ramp up KL loss|
 | intermediate_dim| int: Size of the hidden layer|
 | latent_dim | int: Size of the bottleneck layer|
-| epsilond_std | float: Standard deviation of Normal distribution to sample latent space|
+| epsilon_std | float: Standard deviation of Normal distribution to sample latent space|
 | num_simulated_samples | int: Simulate a compendia with these many samples|
 | num_simulated_experiments| int: Simulate a compendia with these many experiments|
 | lst_num_experiments | list:  List of different numbers of experiments to add to simulated data.  These are the number of sources of technical variation that are added to the simulated data|


### PR DESCRIPTION
This PR updates the notebooks to use the transposed Pseudomonas data matrix to be sample x gene.
By doing this we can remove all the ```.T``` that were originally in the ponyo scripts.

Hopefully this will reduce future bugs since we do not have to keep track of what the dimensions are that are passed between functions but rather force the data to be of the form sample x gene from the start